### PR TITLE
Allow uuid to be an empty string

### DIFF
--- a/lib/network/model/request/subscribe_request.dart
+++ b/lib/network/model/request/subscribe_request.dart
@@ -6,26 +6,34 @@ part 'subscribe_request.g.dart';
 
 @JsonSerializable()
 class SubscribeRequest extends BaseRequest {
-  @JsonKey(name:'action')
+  @JsonKey(name: 'action')
   String action;
 
-  @JsonKey(name:'account', includeIfNull: false)
+  @JsonKey(name: 'account', includeIfNull: false)
   String account;
 
-  @JsonKey(name:'currency', includeIfNull: false)
+  @JsonKey(name: 'currency', includeIfNull: false)
   String currency;
 
-  @JsonKey(name:'uuid', includeIfNull: false)
+  @JsonKey(name: 'uuid', defaultValue: '')
   String uuid;
 
-  @JsonKey(name:'fcm_token_v2', includeIfNull: false)
+  @JsonKey(name: 'fcm_token_v2', includeIfNull: false)
   String fcmToken;
 
-  @JsonKey(name:'notification_enabled')
+  @JsonKey(name: 'notification_enabled')
   bool notificationEnabled;
 
-  SubscribeRequest({this.action = Actions.SUBSCRIBE, this.account, this.currency, this.uuid, this.fcmToken, this.notificationEnabled}) : super();
+  SubscribeRequest(
+      {this.action = Actions.SUBSCRIBE,
+      this.account,
+      this.currency,
+      this.uuid,
+      this.fcmToken,
+      this.notificationEnabled})
+      : super();
 
-  factory SubscribeRequest.fromJson(Map<String, dynamic> json) => _$SubscribeRequestFromJson(json);
+  factory SubscribeRequest.fromJson(Map<String, dynamic> json) =>
+      _$SubscribeRequestFromJson(json);
   Map<String, dynamic> toJson() => _$SubscribeRequestToJson(this);
 }

--- a/lib/network/model/request/subscribe_request.g.dart
+++ b/lib/network/model/request/subscribe_request.g.dart
@@ -11,7 +11,7 @@ SubscribeRequest _$SubscribeRequestFromJson(Map<String, dynamic> json) =>
       action: json['action'] as String ?? Actions.SUBSCRIBE,
       account: json['account'] as String,
       currency: json['currency'] as String,
-      uuid: json['uuid'] as String,
+      uuid: json['uuid'] as String ?? '',
       fcmToken: json['fcm_token_v2'] as String,
       notificationEnabled: json['notification_enabled'] as bool,
     );


### PR DESCRIPTION
After the latest update balance on the home page was blurred (like unfinished request). The response message noticed that during subscribe event one of arguments was null. I figured out that only `uuid` is null hence this solution.

OS: Android 9
Device: LG V30 