### PR TITLE
Switch from bottlerocket vault to goudasoftware fork

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,6 +93,6 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11"
-    implementation "com.bottlerocketstudios:vault:1.4.2"
+    implementation "com.goudasoftware:vault:1.4.5"
     implementation 'androidx.multidex:multidex:2.0.0'
 }


### PR DESCRIPTION
I'm encountering an android build issue using the existing bottlerocket dependency. It appears that this has been removed from its [remote repository](https://mvnrepository.com/artifact/com.bottlerocketstudios/vault), which was jCenter and is deprecated.

In order to get Kalium building with minimal changes, I [forked ](https://github.com/GoudaSoftware/Android-Vault)the bottlerocket repo, modernized the gradle a bit and published it on [sonatype](https://central.sonatype.com/artifact/com.goudasoftware/vault/1.4.5) so it will be accessible to Kalium's current configuration. I don't plan on doing anything more with that repo, which hasn't been updated since 2018.

---
Related: https://github.com/bbedward/flutter_barcode_reader/pull/2
